### PR TITLE
scala 3 benchmark addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ out/
 *.ipr
 *.iws
 jmh-result*.csv
+.bloop
+.metals
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # flink-benchmarks
 
+## Diff with main repository
+
+This fork maintains ScalaMinibecnhmark, which can be run by the following command:
+
+```scala
+ mvn package -Dflink.version=2.1.0 exec:exec \
+  -Dbenchmarks="org.apache.flink.benchmark.ScalaMiniBenchmarks" -DskipTests=true
+```
+
+__Original README content:__
+
+
 This repository contains sets of micro benchmarks designed to run on single machine to help 
 [Apache Flink's](https://github.com/apache/flink) developers assess performance implications of 
 their changes. 

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,9 @@ under the License.
 		<executableJava>java</executableJava>
 		<jmhProfArgument> </jmhProfArgument>
 		<profilerOutputDir>${build.directory}/profile-results</profilerOutputDir>
+		<scala.version.major>3</scala.version.major>
+		<scala.version.minor>7.2</scala.version.minor>
+		<scala.version>${scala.version.major}.${scala.version.minor}</scala.version>
 	</properties>
 
 	<repositories>
@@ -260,6 +263,16 @@ under the License.
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
 			<version>${protobuf.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.flinkextended</groupId>
+			<artifactId>flink-scala-api-2_${scala.version.major}</artifactId>
+			<version>1.2.8</version>
+		</dependency>
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala3-library_${scala.version.major}</artifactId>
+			<version>${scala.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -639,6 +652,35 @@ under the License.
 			</extension>
 		</extensions>
 		<plugins>
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<version>4.8.1</version>
+				<executions>
+					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>scala-test-compile</id>
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<fork>false</fork>
+					<failOnMultipleScalaVersions>false</failOnMultipleScalaVersions>
+					<args>
+						<arg>-encoding</arg>
+						<arg>UTF8</arg>
+					</args>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/org/apache/flink/benchmark/ScalaMiniBenchmarks.java
+++ b/src/main/java/org/apache/flink/benchmark/ScalaMiniBenchmarks.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.benchmark;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.legacy.DiscardingSink;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+/**
+ * Benchmark for serializing Scala Case Classes.
+ */
+public class ScalaMiniBenchmarks extends BenchmarkBase {
+
+    protected static final int RECORDS_PER_INVOCATION = 300_000;
+
+    public static void main(String[] args) throws RunnerException {
+        Options options =
+                new OptionsBuilder()
+                        .verbosity(VerboseMode.NORMAL)
+                        .include(String.format(".*%s.*", ScalaMiniBenchmarks.class.getCanonicalName()))
+                        .build();
+        new Runner(options).run();
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(value = SerializationFrameworkMiniBenchmarks.RECORDS_PER_INVOCATION)
+    public void serializerScala(FlinkEnvironmentContext context) throws Exception {
+        StreamExecutionEnvironment env = context.env;
+        env.setParallelism(4);
+
+        env.addSource(new ScalaSource(RECORDS_PER_INVOCATION, 10), ScalaCaseClass$.MODULE$.ti())
+                .rebalance()
+                .addSink(new DiscardingSink<>());
+
+        env.execute();
+    }
+}

--- a/src/main/scala/org/apache/flink/benchmark/scalaSource.scala
+++ b/src/main/scala/org/apache/flink/benchmark/scalaSource.scala
@@ -1,0 +1,34 @@
+package org.apache.flink.benchmark
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flinkx.api.serializers._
+import org.apache.flink.benchmark.functions.BaseSourceWithKeyRange
+
+final case class ScalaOperation(id: Int, name: String)
+
+final case class ScalaCaseClass(
+                                 var id: Int,
+                                 name: String,
+                                 operationNames: Array[String],
+                                 operations: Array[ScalaOperation],
+                                 otherId1: Int, otherId2: Int, otherId3: Int, someObject: String
+                               )
+
+object ScalaCaseClass {
+  val ti: TypeInformation[ScalaCaseClass] = deriveTypeInformation[ScalaCaseClass]
+}
+
+class ScalaSource(numEvents: Int, numKeys: Int) extends BaseSourceWithKeyRange[ScalaCaseClass](numEvents, numKeys) {
+  private val serialVersionUID = 2941333602938145526L
+  @transient private var template: ScalaCaseClass = null
+
+  override protected def init(): Unit = {
+    super.init()
+    template = ScalaCaseClass(0, "myName", Array("op1", "op2", "op3", "op4"), Array(ScalaOperation(1, "op1"), ScalaOperation(2, "op2"), ScalaOperation(3, "op3")), 1, 2, 3, "null")
+  }
+
+  override protected def getElement(keyId: Int): ScalaCaseClass = {
+    template.id = keyId
+    template
+  }
+}


### PR DESCRIPTION
Scala MiniBenchmark addition for Scala 3 with flinkextended/flink-scala-api.

Note: at the moment only Scala Benchmark works. Original benchmarks fail due to multiple Scala version on CLASSPATH which makes standard Kryo framework throw an error. It is hard to say whether it can be avoided. It requires deeper investigation.